### PR TITLE
Datetime, Time and Random

### DIFF
--- a/docs/runtime/lib/datetime.mjs
+++ b/docs/runtime/lib/datetime.mjs
@@ -1,0 +1,76 @@
+import { write, read } from "./ffi.mjs";
+
+export const spec = {
+  now:           { args: [],                                      ret: "str" },  // current local datetime
+  utcnow:        { args: [],                                      ret: "str" },  // current UTC datetime
+  today:         { args: [],                                      ret: "str" },  // current local date
+  date:          { args: ["num","num","num"],                ret: "str" },  // year, month, day
+  time:          { args: ["num","num","num","num"],        ret: "str" },  // hr, min, sec, μsec
+  datetime:      { args: ["num","num","num","num","num","num","num"], ret: "str" },  // y,m,d,hr,min,sec,μsec
+  fromtimestamp: { args: ["num"],                                ret: "str" },  // seconds since epoch local
+  utcfromtimestamp: { args: ["num"],                             ret: "str" },  // seconds since epoch UTC
+  timestamp:     { args: ["str"],                                ret: "num" },  // ISO string -> seconds since epoch
+  strftime:      { args: ["str","str"],                        ret: "str" },  // dt_str, format
+  strptime:      { args: ["str","str"],                        ret: "str" },  // text, format -> ISO
+  isoformat:     { args: ["str"],                                ret: "str" },  // ensure ISO formatting
+  weekday:       { args: ["str"],                                ret: "num" },  // 0=Mon..6=Sun
+  isoweekday:    { args: ["str"],                                ret: "num" },  // 1=Mon..7=Sun
+  add_seconds:   { args: ["str","num"],                        ret: "str" },  // dt_str, seconds
+  sub_seconds:   { args: ["str","num"],                        ret: "str" },  // dt_str, seconds
+};
+
+export class MystiaDatetimeLib {
+  constructor() {
+    this.functions = {
+      now: () => write(this.instance, "str", new Date().toString()),
+      utcnow: () => write(this.instance, "str", new Date().toUTCString()),
+      today: () => write(this.instance, "str", new Date().toISOString().slice(0,10)),
+      date: (y,m,d) => {
+        const dt = new Date(read(this.instance,"num",y), read(this.instance,"num",m)-1, read(this.instance,"num",d));
+        return write(this.instance, "str", dt.toISOString().slice(0,10));
+      },
+      time: (hr,min,sec,μ) => {
+        const pad = n => String(n).padStart(2,'0');
+        return write(this.instance, "str", `${pad(read(this.instance,"num",hr))}:${pad(read(this.instance,"num",min))}:${pad(read(this.instance,"num",sec))}.${String(read(this.instance,"num",μ)).padStart(6,'0')}`);
+      },
+      datetime: (y,m,d,hr,min,sec,μ) => {
+        const dt = new Date(
+          read(this.instance,"num",y),
+          read(this.instance,"num",m)-1,
+          read(this.instance,"num",d),
+          read(this.instance,"num",hr),
+          read(this.instance,"num",min),
+          read(this.instance,"num",sec),
+          Math.floor(read(this.instance,"num",μ)/1000)
+        );
+        return write(this.instance, "str", dt.toISOString());
+      },
+      fromtimestamp: (sec) => write(this.instance, "str", new Date(read(this.instance,"num",sec)*1000).toString()),
+      utcfromtimestamp: (sec) => write(this.instance, "str", new Date(read(this.instance,"num",sec)*1000).toUTCString()),
+      timestamp: (iso) => Date.parse(read(this.instance,"str",iso)) / 1000,
+      strftime: (iso,fmt) => {
+        const dt = new Date(read(this.instance,"str",iso));
+        return write(this.instance, "str", new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyle: 'medium' }).format(dt));
+      },
+      strptime: (text, fmt) => {
+        const dt = new Date(read(this.instance,"str",text));
+        return write(this.instance, "str", dt.toISOString());
+      },
+      isoformat: (iso) => write(this.instance, "str", new Date(read(this.instance,"str",iso)).toISOString()),
+      weekday: (iso) => new Date(read(this.instance,"str",iso)).getDay() === 0 ? 6 : new Date(read(this.instance,"str",iso)).getDay() - 1,
+      isoweekday: (iso) => new Date(read(this.instance,"str",iso)).getDay() === 0 ? 7 : new Date(read(this.instance,"str",iso)).getDay(),
+      add_seconds: (iso,sec) => write(this.instance, "str", new Date(Date.parse(read(this.instance,"str",iso)) + read(this.instance,"num",sec)*1000).toISOString()),
+      sub_seconds: (iso,sec) => write(this.instance, "str", new Date(Date.parse(read(this.instance,"str",iso)) - read(this.instance,"num",sec)*1000).toISOString()),
+    };
+  }
+
+  set_wasm(instance) {
+    this.instance = instance;
+  }
+
+  bridge() {
+    return Object.fromEntries(
+      Object.entries(this.functions).map(([k,v]) => [k, (...a) => v(...a)])
+    );
+  }
+}

--- a/docs/runtime/lib/datetime.mjs
+++ b/docs/runtime/lib/datetime.mjs
@@ -1,4 +1,4 @@
-import { write, read } from "./ffi.mjs";
+import { write, read } from "../ffi.mjs";
 
 export const spec = {
   now:           { args: [],                                      ret: "str" },  // current local datetime

--- a/docs/runtime/lib/random.mjs
+++ b/docs/runtime/lib/random.mjs
@@ -1,0 +1,157 @@
+import { write, read } from "./ffi.mjs";
+
+class MersenneTwister {
+  constructor(seed) {
+    this.N = 624;
+    this.M = 397;
+    this.MATRIX_A = 0x9908b0df;
+    this.UPPER_MASK = 0x80000000;
+    this.LOWER_MASK = 0x7fffffff;
+    this.mt = new Array(this.N);
+    this.mti = this.N + 1;
+    this.init_genrand(seed ?? new Date().getTime());
+  }
+  init_genrand(s) {
+    this.mt[0] = s >>> 0;
+    for (this.mti = 1; this.mti < this.N; this.mti++) {
+      const prev = this.mt[this.mti - 1];
+      const x = prev ^ (prev >>> 30);
+      this.mt[this.mti] = (((((x & 0xffff0000) >>> 16) * 1812433253) << 16)
+                        + (x & 0x0000ffff) * 1812433253 + this.mti) >>> 0;
+    }
+  }
+  genrand_int32() {
+    let y;
+    const mag01 = [0, this.MATRIX_A];
+    if (this.mti >= this.N) {
+      let kk;
+      for (kk = 0; kk < this.N - this.M; kk++) {
+        y = (this.mt[kk] & this.UPPER_MASK) | (this.mt[kk + 1] & this.LOWER_MASK);
+        this.mt[kk] = this.mt[kk + this.M] ^ (y >>> 1) ^ mag01[y & 1];
+      }
+      for (; kk < this.N - 1; kk++) {
+        y = (this.mt[kk] & this.UPPER_MASK) | (this.mt[kk + 1] & this.LOWER_MASK);
+        this.mt[kk] = this.mt[kk + (this.M - this.N)] ^ (y >>> 1) ^ mag01[y & 1];
+      }
+      y = (this.mt[this.N - 1] & this.UPPER_MASK) | (this.mt[0] & this.LOWER_MASK);
+      this.mt[this.N - 1] = this.mt[this.M - 1] ^ (y >>> 1) ^ mag01[y & 1];
+      this.mti = 0;
+    }
+    y = this.mt[this.mti++];
+    y ^= y >>> 11;
+    y ^= (y << 7) & 0x9d2c5680;
+    y ^= (y << 15) & 0xefc60000;
+    y ^= y >>> 18;
+    return y >>> 0;
+  }
+  genrand_real2() {
+    return this.genrand_int32() * (1.0 / 4294967296.0);
+  }
+}
+
+class Random {
+  constructor(seed) {
+    this._mt = new MersenneTwister(seed);
+    this._gaussNext = null;
+  }
+  seed(s) { this._mt.init_genrand(s); }
+  getstate() { return { state: this._mt.mt.slice(), index: this._mt.mti }; }
+  setstate(st) { this._mt.mt = st.state.slice(); this._mt.mti = st.index; }
+  random() { return this._mt.genrand_real2(); }
+  getrandbits(k) {
+    let result = 0n, bits = 0;
+    while (bits < k) {
+      const r = BigInt(this._mt.genrand_int32());
+      const take = BigInt(Math.min(k - bits, 32));
+      result |= (r & ((1n << take) - 1n)) << BigInt(bits);
+      bits += Number(take);
+    }
+    return result;
+  }
+  randbytes(n) {
+    const buf = Buffer.alloc(n);
+    for (let i = 0; i < n; i++) buf[i] = this._mt.genrand_int32() & 0xff;
+    return buf;
+  }
+  randrange(start, stop = null, step = 1) {
+    if (stop === null) { stop = start; start = 0; }
+    const width = stop - start;
+    if (step === 1) return start + Math.floor(this.random() * width);
+    const n = Math.floor((width + step - 1) / step);
+    return start + step * Math.floor(this.random() * n);
+  }
+  randint(a, b) { return this.randrange(a, b + 1); }
+  uniform(a, b) { return a + (b - a) * this.random(); }
+  triangular(low=0, high=1, mode=null) {
+    if (mode===null) mode=(low+high)/2;
+    const u=this.random(), c=(mode-low)/(high-low);
+    return u<c ? low+Math.sqrt(u*(high-low)*(mode-low)) : high-Math.sqrt((1-u)*(high-low)*(high-mode));
+  }
+  gauss(mu=0,sigma=1) {
+    if(this._gaussNext!==null){ const v=this._gaussNext; this._gaussNext=null; return v*sigma+mu; }
+    let u1,u2; do{u1=this.random();u2=this.random();} while(u1<=Number.EPSILON);
+    const mag=Math.sqrt(-2*Math.log(u1));
+    const z0=mag*Math.cos(2*Math.PI*u2), z1=mag*Math.sin(2*Math.PI*u2);
+    this._gaussNext=z1; return z0*sigma+mu;
+  }
+  normalvariate(mu,sigma){return this.gauss(mu,sigma);}  
+  lognormvariate(mu,sigma){return Math.exp(this.normalvariate(mu,sigma));}
+  expovariate(lambd){ if(lambd<=0) throw Error('lambda>0'); return -Math.log(1-this.random())/lambd; }
+  gammavariate(alpha,beta){ if(alpha>1){ const d=alpha-1/3, c=1/Math.sqrt(9*d); while(true){ let x,v; do{ x=this.gauss(); v=1+c*x;} while(v<=0); v=v*v*v; const u=this.random(); if(u<1-0.0331*x*x*x*x) return d*v*beta; if(Math.log(u)<0.5*x*x+d*(1-v+Math.log(v))) return d*v*beta;} } if(alpha===1) return -Math.log(1-this.random())*beta; return this.gammavariate(alpha+1,1)*Math.pow(this.random(),1/alpha)*beta; }
+  betavariate(a,b){const y1=this.gammavariate(a,1), y2=this.gammavariate(b,1); return y1/(y1+y2);}
+  paretovariate(a){ if(a<=0) throw Error('alpha>0'); return Math.pow(this.random(),-1/a); }
+  weibullvariate(a,b){ if(a<=0||b<=0) throw Error('alpha/beta>0'); return b*Math.pow(-Math.log(1-this.random()),1/a); }
+  vonmisesvariate(mu,kappa){ const TWO_PI=2*Math.PI; if(kappa<=1e-6) return mu+TWO_PI*this.random(); const a=1+Math.sqrt(1+4*kappa*kappa), b=(a-Math.sqrt(2*a))/(2*kappa), r=(1+b*b)/(2*b); while(true){ const u1=this.random(), z=Math.cos(Math.PI*u1), f=(1+r*z)/(r+z), c=kappa*(r-f), u2=this.random(); if(u2<c*(2-c)||u2<=c*Math.exp(1-c)){ const u3=this.random(), theta=u3>0.5?Math.acos(f):-Math.acos(f); return (mu+theta+TWO_PI)%TWO_PI; }} }
+  choice(seq){ if(seq.length===0) throw Error('empty'); return seq[Math.floor(this.random()*seq.length)]; }
+  choices(pop, weights=null, cum_weights=null, k=1){ const n=pop.length; if(n===0||k<0) throw Error('invalid'); let cum=[]; if(cum_weights) cum=cum_weights.slice(); else if(weights){ let t=0; for(let w of weights){t+=w; cum.push(t);} } else { for(let i=0;i<n;i++) cum.push(i+1);} const total=cum[cum.length-1], res=[]; for(let i=0;i<k;i++){ const r=this.random()*total, idx=cum.findIndex(c=>r<c); res.push(pop[idx]); } return res; }
+  shuffle(arr){ for(let i=arr.length-1;i>0;i--){ const j=Math.floor(this.random()*(i+1)); [arr[i],arr[j]]=[arr[j],arr[i]];} return arr; }
+  sample(pop,k){ const n=pop.length; if(k<0||k>n) throw Error('invalid'); const pool=pop.slice(), res=[]; for(let i=0;i<k;i++){ const idx=Math.floor(this.random()*pool.length); res.push(pool[idx]); pool.splice(idx,1);} return res; }
+}
+
+export const __spec__ = {
+  seed:             { args: ["int"],        ret: "void" },
+  getstate:         { args: [],              ret: "str"  },
+  setstate:         { args: ["str"],        ret: "void" },
+  random:           { args: [],              ret: "num"  },
+  getrandbits:      { args: ["num"],        ret: "num"  },
+  randbytes:        { args: ["num"],        ret: "str"  },
+  randrange:        { args: ["num","num","num"], ret: "num" },
+  randint:          { args: ["num","num"],ret: "num"  },
+  uniform:          { args: ["num","num"],ret: "num"  },
+  triangular:       { args: ["num","num","num"], ret: "num" },
+  gauss:            { args: ["num","num"],ret: "num"  },
+  normalvariate:    { args: ["num","num"],ret: "num"  },
+  lognormvariate:   { args: ["num","num"],ret: "num"  },
+  expovariate:      { args: ["num"],        ret: "num"  },
+  gammavariate:     { args: ["num","num"],ret: "num"  },
+  betavariate:      { args: ["num","num"],ret: "num"  },
+  paretovariate:    { args: ["num"],        ret: "num"  },
+  weibullvariate:   { args: ["num","num"],ret: "num"  },
+  vonmisesvariate:  { args: ["num","num"],ret: "num"  },
+  choice:           { args: ["str"],        ret: "str"  },
+  choices:          { args: ["str","str","str","num"], ret: "str"  },
+  shuffle:          { args: ["str"],        ret: "str"  },
+  sample:           { args: ["str","num"],ret: "str"  }
+};
+
+export class MystiaRandomLib {
+  constructor() { this.rng = new Random(); this.functions = Object.create(null);
+    for(const key of Object.keys(__spec__)){
+      this.functions[key] = (...ptrs) => {
+        const args = ptrs.map((p,i)=>{
+          const type = __spec__[key].args[i];
+          return read(this.instance, type, p);
+        });
+        const val = this.rng[key](...args);
+        const retType = __spec__[key].ret;
+        if(retType === 'void') return;
+        const out = (retType==='str'||retType==='num')
+                   ? write(this.instance, retType, val instanceof Buffer? val.toString('base64'): val)
+                   : val;
+        return out;
+      };
+    }
+  }
+  set_wasm(instance){ this.instance = instance; }
+  bridge(){ const b={}; for(const k of Object.keys(this.functions)) b[k]=(...a)=>this.functions[k](...a); return b; }
+}

--- a/docs/runtime/lib/random.mjs
+++ b/docs/runtime/lib/random.mjs
@@ -1,4 +1,4 @@
-import { write, read } from "./ffi.mjs";
+import { write, read } from "../ffi.mjs";
 
 class MersenneTwister {
   constructor(seed) {

--- a/docs/runtime/lib/time.mjs
+++ b/docs/runtime/lib/time.mjs
@@ -1,0 +1,159 @@
+import { write, read } from "../ffi.mjs";
+
+export const spec = {
+  time:             { args: [],              ret: "num" },
+  time_ns:          { args: [],              ret: "num" },
+  perf_counter:     { args: [],              ret: "num" },
+  perf_counter_ns:  { args: [],              ret: "num" },
+  monotonic:        { args: [],              ret: "num" },
+  monotonic_ns:     { args: [],              ret: "num" },
+  process_time:     { args: [],              ret: "num" },
+  process_time_ns:  { args: [],              ret: "num" },
+  sleep:            { args: ["num"],         ret: "void" },
+  ctime:            { args: ["num"],         ret: "str" },
+  asctime:          { args: ["tuple"],       ret: "str" },
+  localtime:        { args: ["num"],         ret: "tuple" },
+  gmtime:           { args: ["num"],         ret: "tuple" },
+  mktime:           { args: ["tuple"],       ret: "num" },
+  strftime:         { args: ["str", "tuple"],ret: "str" },
+  strptime:         { args: ["str","str"],   ret: "tuple" },
+  tzset:            { args: ["str"],         ret: "void" },
+  timezone:         { args: [],              ret: "num" },
+  daylight:         { args: [],              ret: "bool" },
+  tzname:           { args: [],              ret: "str" },
+};
+
+export class MystiaTimeLib {
+  constructor() {
+    this.functions = {
+      time:             () => write(this.instance, "num", Date.now() / 1000),
+      time_ns:          () => write(this.instance, "num", Date.now() * 1e6),
+      perf_counter:     () => {
+        const [s, ns] = process.hrtime();
+        return write(this.instance, "num", s + ns / 1e9);
+      },
+      perf_counter_ns:  () => {
+        const [s, ns] = process.hrtime();
+        return write(this.instance, "num", s * 1e9 + ns);
+      },
+      monotonic:        () => {
+        const [s, ns] = process.hrtime();
+        return write(this.instance, "num", s + ns / 1e9);
+      },
+      monotonic_ns:     () => {
+        const [s, ns] = process.hrtime();
+        return write(this.instance, "num", s * 1e9 + ns);
+      },
+      process_time:     () => {
+        const u = process.cpuUsage();
+        return write(this.instance, "num", (u.user + u.system) / 1e6);
+      },
+      process_time_ns:  () => {
+        const u = process.cpuUsage();
+        return write(this.instance, "num", (u.user + u.system) * 1000);
+      },
+      sleep:            (secs) => {
+        const ms = read(this.instance, "num", secs) * 1000;
+        const start = Date.now();
+        while (Date.now() - start < ms) { /* busy-wait */ }
+      },
+      ctime:            (secs) => {
+        const t = read(this.instance, "num", secs);
+        return write(this.instance, "str", new Date((t || Date.now()/1000) * 1000).toUTCString());
+      },
+      asctime:          (tpl) => {
+        const t = JSON.parse(read(this.instance, "str", tpl));
+        // Python asctime: "Www Mmm dd hh:mm:ss yyyy"
+        const d = new Date(Date.UTC(t[0], t[1]-1, t[2], t[3], t[4], t[5]));
+        return write(this.instance, "str", d.toUTCString().replace(" GMT", ""));
+      },
+      gmtime:           (secs) => {
+        const t = read(this.instance, "num", secs) || Date.now() / 1000;
+        const d = new Date(t * 1000);
+        const arr = [
+          d.getUTCFullYear(),
+          d.getUTCMonth() + 1,
+          d.getUTCDate(),
+          d.getUTCHours(),
+          d.getUTCMinutes(),
+          d.getUTCSeconds(),
+          d.getUTCDay(),
+          Math.floor((Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()) -
+                       Date.UTC(d.getUTCFullYear(), 0, 1)) / 86400000) + 1,
+          0
+        ];
+        return write(this.instance, "str", JSON.stringify(arr));
+      },
+      localtime:        (secs) => {
+        const t = read(this.instance, "num", secs) || Date.now() / 1000;
+        const d = new Date(t * 1000);
+        const arr = [
+          d.getFullYear(),
+          d.getMonth() + 1,
+          d.getDate(),
+          d.getHours(),
+          d.getMinutes(),
+          d.getSeconds(),
+          d.getDay(),
+          Math.floor((d - new Date(d.getFullYear(), 0, 1)) / 86400000) + 1,
+          d.getTimezoneOffset() < 0 ? 1 : 0
+        ];
+        return write(this.instance, "str", JSON.stringify(arr));
+      },
+      mktime:           (tpl) => {
+        const t = JSON.parse(read(this.instance, "str", tpl));
+        const d = new Date(t[0], t[1]-1, t[2], t[3], t[4], t[5]);
+        return write(this.instance, "num", d.getTime() / 1000);
+      },
+      strftime:         (fmt, tpl) => {
+        const f = read(this.instance, "str", fmt);
+        const t = JSON.parse(read(this.instance, "str", tpl));
+        const d = new Date(Date.UTC(t[0], t[1]-1, t[2], t[3], t[4], t[5]));
+        // minimal subset: %Y, %m, %d, %H, %M, %S
+        const pad = (n) => n.toString().padStart(2, "0");
+        return write(this.instance, "str",
+          f.replace(/%Y/g, d.getUTCFullYear())
+           .replace(/%m/g, pad(d.getUTCMonth()+1))
+           .replace(/%d/g, pad(d.getUTCDate()))
+           .replace(/%H/g, pad(d.getUTCHours()))
+           .replace(/%M/g, pad(d.getUTCMinutes()))
+           .replace(/%S/g, pad(d.getUTCSeconds()))
+        );
+      },
+      strptime:         (_s,_f) => {
+        throw new Error("strptime not implemented");
+      },
+      tzset:            (tz) => {
+        process.env.TZ = read(this.instance, "str", tz);
+      },
+      timezone:         () => {
+        // seconds west of UTC
+        return write(this.instance, "num", -new Date().getTimezoneOffset() * 60);
+      },
+      daylight:         () => {
+        // crude: assume DST if offset varies
+        const jan = new Date(new Date().getFullYear(),0,1).getTimezoneOffset();
+        const jul = new Date(new Date().getFullYear(),6,1).getTimezoneOffset();
+        return jan !== jul;
+      },
+      tzname:           () => {
+        const fmt = new Intl.DateTimeFormat("en", { timeZoneName: "short" });
+        const parts = fmt.formatToParts(new Date());
+        const name = parts.find(p => p.type === "timeZoneName")?.value || "";
+        return write(this.instance, "str", name);
+      },
+    };
+  }
+
+  set_wasm(instance) {
+    this.instance = instance;
+  }
+
+  bridge() {
+    return Object.fromEntries(
+      Object.keys(spec).map(name =>
+        [name, (...args) => this.functions[name](...args)]
+      )
+    );
+  }
+}

--- a/docs/runtime/node.mjs
+++ b/docs/runtime/node.mjs
@@ -4,6 +4,7 @@ import { MystiaMathLib } from "./lib/math.mjs";
 import { MystiaOSLib } from "./lib/os.mjs";
 import { MystiaRandomLib } from "./lib/random.mjs";
 import { MystiaDatetimeLib } from "./lib/datetime.mjs";
+import { MystiaTimeLib } from "./lib/time.mjs";
 import { module } from "./module.mjs";
 import { read } from "./ffi.mjs";
 
@@ -12,6 +13,7 @@ const moduleClasses = {
     os: MystiaOSLib,
     random: MystiaRandomLib,
     datetime: MystiaDatetimeLib,
+    time: MystiaTimeLib,
 };
 
 export async function mystia(code, customModules = {}) {

--- a/docs/runtime/node.mjs
+++ b/docs/runtime/node.mjs
@@ -2,12 +2,16 @@ import { mystia as compile } from "../wasm/node/mystia_wasm.js";
 import { MystiaNodeLib } from "./lib/std.mjs";
 import { MystiaMathLib } from "./lib/math.mjs";
 import { MystiaOSLib } from "./lib/os.mjs";
+import { MystiaRandomLib } from "./lib/random.mjs";
+import { MystiaDatetimeLib } from "./lib/datetime.mjs";
 import { module } from "./module.mjs";
 import { read } from "./ffi.mjs";
 
 const moduleClasses = {
     math: MystiaMathLib,
     os: MystiaOSLib,
+    random: MystiaRandomLib,
+    datetime: MystiaDatetimeLib,
 };
 
 export async function mystia(code, customModules = {}) {

--- a/docs/runtime/web.mjs
+++ b/docs/runtime/web.mjs
@@ -1,11 +1,15 @@
 import init, { mystia as compile } from "../wasm/web/mystia_wasm.js";
 import { MystiaWebLib } from "./lib/std.mjs";
 import { MystiaMathLib } from "./lib/math.mjs";
+import { MystiaRandomLib } from "./lib/random.mjs";
+import { MystiaDatetimeLib } from "./lib/datetime.mjs";
 import { module } from "./module.mjs";
 import { read } from "./ffi.mjs";
 
 const moduleClasses = {
     math: MystiaMathLib,
+    random: MystiaRandomLib,
+    datetime: MystiaDatetimeLib,
 };
 
 await init();

--- a/docs/runtime/web.mjs
+++ b/docs/runtime/web.mjs
@@ -3,6 +3,7 @@ import { MystiaWebLib } from "./lib/std.mjs";
 import { MystiaMathLib } from "./lib/math.mjs";
 import { MystiaRandomLib } from "./lib/random.mjs";
 import { MystiaDatetimeLib } from "./lib/datetime.mjs";
+import { MystiaTimeLib } from "./lib/time.mjs";
 import { module } from "./module.mjs";
 import { read } from "./ffi.mjs";
 
@@ -10,6 +11,7 @@ const moduleClasses = {
     math: MystiaMathLib,
     random: MystiaRandomLib,
     datetime: MystiaDatetimeLib,
+    time: MystiaTimeLib,
 };
 
 await init();


### PR DESCRIPTION
Add datetime, time and random to the library

Usage:
Mystia REPL
load datetime::{now():str}
now()
> Tue May 27 2025 08:38:01 GMT+0900 (日本標準時)

Mystia REPL
load time::{time():num}
time()
> 1748306442.865

time()
> 1748306445.248

load random::{randrange(from:int,to:int,step:int):int}
randrange(0,21,2)
> 0

randrange(0,21,2)
> 14

randrange(0,21,2)
> 18

randrange(0,21,2)
> 12

randrange(0,21,2)
> 18